### PR TITLE
feat: infer patterns from initial rename requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ require("live-rename").setup({
     -- Otherwise fallback to using `<cword>`.
     prepare_rename = true,
     request_timeout = 1500,
+    -- Make an initial `textDocument/rename` request to gather other
+    -- occurences which are edited and use these ranges to preview.
+    -- If disabled only the word under the cursor will have a preview.
     show_other_ocurrences = true,
+    -- Try to infer patterns from the initial `textDocument/rename` request
+    -- and use these to show hopefully better edit previews.
+    use_patterns = true,
     keys = {
         submit = {
             { "n", "<cr>" },


### PR DESCRIPTION
This improves some cases where a rename, implies more than just changing the plain name.

For example when renaming a variable in rust that is used in short form struct initialization:
![image](https://github.com/user-attachments/assets/5eec7ae6-57f9-448e-9275-8debd8224789)

Or when renaming a quoted identifier in lua:
![image](https://github.com/user-attachments/assets/e093047b-5906-4b0a-b58f-ebbe4b65d7e2)

