### PR TITLE
fix: don't error if range start/end are not on the same line

### DIFF
--- a/lua/live-rename.lua
+++ b/lua/live-rename.lua
@@ -231,7 +231,9 @@ local function rename_refs_handler(transaction_id, unique_name)
             end
 
             local range = edit.range
-            assert(range.start.line == range["end"].line)
+            if range.start.line ~= range["end"].line then
+                return
+            end
             if range.start.line ~= pos.line then
                 -- on other line
                 table.insert(editing_ranges, { range = range, pattern = pattern })


### PR DESCRIPTION
Hey :wave: 

I've encountered errors when trying to use this plugin with haskell-language-server, because it can respond with document edits with ranges that span multiple lines.

This is not an ideal fix, because it makes the preview behaviour inconsistent, but in my opinion it's better than throwing an error for now.
Perhaps there's a better long term solution?

If you'd like I'll try to come up with a reproducible example to share in an issue.